### PR TITLE
Packet_RequestLevelUp Exploit

### DIFF
--- a/Orion Server/Modules/modHandleData.vb
+++ b/Orion Server/Modules/modHandleData.vb
@@ -2241,7 +2241,12 @@
         buffer = New ByteBuffer
         buffer.WriteBytes(data)
         If buffer.ReadLong <> ClientPackets.CRequestLevelUp Then Exit Sub
-
+        
+        ' Prevent hacking
+        If GetPlayerAccess(Index) < ADMIN_CREATOR Then
+            Exit Sub
+        End If
+        
         SetPlayerExp(index, GetPlayerNextLevel(index))
         CheckPlayerLevelUp(index)
 


### PR DESCRIPTION
To many engines leave this open :S
- Fixes the ability to level up without perms to (Packet sending on client could level it up with out any permissions)
